### PR TITLE
Potential fix for code scanning alert no. 30: Uncontrolled data used in path expression

### DIFF
--- a/HTML/html.nodejs.dj.upayan.dev/web/server.js
+++ b/HTML/html.nodejs.dj.upayan.dev/web/server.js
@@ -1,7 +1,7 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
-
+const ROOT = path.resolve(__dirname, 'public');
 const hostname = `0.0.0.0`;
 const port = 3000;
 
@@ -28,7 +28,14 @@ const server = http.createServer((req, res) => {
     } else {
         filePath = './routes' + req.url;
     }
-
+    // Normalize the file path
+    filePath = path.resolve(ROOT, filePath);
+    // Check that the file path is within the root directory
+    if (!filePath.startsWith(ROOT)) {
+        res.writeHead(403);
+        res.end('Access denied');
+        return;
+    }
     // Check if the path is a directory and append index.html
     if (fs.existsSync(filePath) && fs.lstatSync(filePath).isDirectory()) {
         filePath = path.join(filePath, 'index.html');


### PR DESCRIPTION
Potential fix for [https://github.com/upayanmazumder/DevJourney/security/code-scanning/30](https://github.com/upayanmazumder/DevJourney/security/code-scanning/30)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root directory. We can achieve this by normalizing the path using `path.resolve` and then checking that the normalized path starts with the root directory. This will prevent directory traversal attacks by ensuring that the file path does not escape the intended directory.

1. Define a root directory for the server.
2. Normalize the constructed file path using `path.resolve`.
3. Check that the normalized path starts with the root directory.
4. If the check fails, respond with a 403 Forbidden status.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
